### PR TITLE
Fix order of dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,8 +45,8 @@ pytz==2016.3
 pyzmq==15.2.0
 qtconsole==4.2.1
 requests==2.9.1
-scikit-learn==0.17.1
 scipy==0.17.0
+scikit-learn==0.17.1
 setuptools==19.4
 simplegeneric==0.8.1
 singledispatch==3.4.0.3


### PR DESCRIPTION
Scikit-learn is dependent upon having working versions of numpy and scipy, i learned recently.  Installing scipy before scikit-learn resolved error messages for me during install.
